### PR TITLE
feat: split+indexを一括実行する run コマンドの追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- `run` コマンド: split + index を一括実行
 - `split` コマンド: PDFを固定ページ数ごとにMarkdownチャンクファイルへ分割
 - `index` コマンド: チャンクファイル群からメタ情報・抜粋付きの `index.md` を生成
 - YAML frontmatter 付きチャンクファイル出力（source, chunk, page_start, page_end）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,19 +139,21 @@ class Summarizer(ABC):
 ### コマンド体系
 
 ```bash
-# チャンク生成
+# 一括実行（split → index）
+pdfchunk run <pdf_path> <output_dir> [options]
+
+# チャンク生成のみ
 pdfchunk split <pdf_path> <output_dir> [options]
 
-# インデックス生成
+# インデックス生成のみ
 pdfchunk index <output_dir> [options]
 ```
 
 ### オプション
 
-- `--chunk-size` — チャンクあたりのページ数（default: 10）
-- `--excerpt-lines` — indexに含める各チャンクの抜粋行数（default: 5）
-- `--summarize-chunks` — index生成時に各チャンクの要約を付加する（default: off）
-- `--overwrite` — 既存ファイルを上書きする（default: off、既存時はエラー）
+- `--chunk-size` — チャンクあたりのページ数（default: 10）（run, split）
+- `--excerpt-lines` — indexに含める各チャンクの抜粋行数（default: 5）（run, index）
+- `--overwrite` — 既存ファイルを上書きする（default: off、既存時はエラー）（run, split, index）
 
 ### オーケストレーション
 
@@ -180,6 +182,13 @@ pdfchunk index <output_dir> [options]
 
 - `--overwrite` なし: `index.md` が既に存在すればエラー
 - `--overwrite` あり: `index.md` を上書き
+
+`run` コマンドの処理フロー:
+
+1. `split` の処理フローを実行
+1. `index` の処理フローを実行
+
+`--overwrite` の挙動は `split` と `index` それぞれと同一
 
 ## 制約
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,41 @@ Python 3.13 以上が必要。
 
 ## 使い方
 
-### チャンク生成（split）
+### 一括実行（run）
 
-PDFを固定ページ数ごとに分割し、Markdownファイルとして出力する。
+PDFのチャンク分割からインデックス生成までを一括実行する。
+
+```bash
+pdfchunk run <pdf_path> <output_dir>
+```
+
+```bash
+# 例: 5ページごとに分割して一括処理
+pdfchunk run report.pdf output/ --chunk-size 5
+
+# 抜粋行数を変更
+pdfchunk run report.pdf output/ --excerpt-lines 10
+
+# 既存ファイルを上書き
+pdfchunk run report.pdf output/ --overwrite
+```
+
+| オプション        | デフォルト | 説明                           |
+| ----------------- | ---------- | ------------------------------ |
+| `--chunk-size`    | 10         | チャンクあたりのページ数       |
+| `--excerpt-lines` | 5          | 各チャンクから抽出する抜粋行数 |
+| `--overwrite`     | off        | 既存ファイルを削除して再生成   |
+
+### チャンク生成のみ（split）
+
+チャンク分割だけを個別に実行する。
 
 ```bash
 pdfchunk split <pdf_path> <output_dir>
 ```
 
 ```bash
-# 例: 5ページごとに分割
 pdfchunk split report.pdf output/ --chunk-size 5
-
-# 既存のチャンクファイルを上書き
 pdfchunk split report.pdf output/ --overwrite
 ```
 
@@ -36,19 +58,16 @@ pdfchunk split report.pdf output/ --overwrite
 | `--chunk-size` | 10         | チャンクあたりのページ数             |
 | `--overwrite`  | off        | 既存チャンクファイルを削除して再生成 |
 
-### インデックス生成（index）
+### インデックス生成のみ（index）
 
-チャンクファイル群から `index.md` を生成する。各チャンクのメタ情報と冒頭の抜粋を一覧化する。
+`split` が生成したチャンクファイル群から `index.md` を生成する。
 
 ```bash
 pdfchunk index <output_dir>
 ```
 
 ```bash
-# 抜粋行数を変更
 pdfchunk index output/ --excerpt-lines 10
-
-# 既存の index.md を上書き
 pdfchunk index output/ --overwrite
 ```
 

--- a/src/pdfchunk/cli.py
+++ b/src/pdfchunk/cli.py
@@ -159,8 +159,22 @@ def run(
     overwrite: bool,
 ) -> None:
     """PDFのチャンク分割からインデックス生成までを一括実行する。"""
-    parser = Pymupdf4llmParser()
     out = Path(output_dir)
+
+    # split + index 両方の事前条件を一括チェック（部分的な成果物の残存を防止）
+    if not overwrite:
+        existing_chunks = list(out.glob(CHUNK_FILE_PATTERN)) if out.exists() else []
+        if existing_chunks:
+            raise click.ClickException(
+                f"出力先に既存のチャンクファイルがあります。--overwrite を指定してください: {out}"
+            )
+        index_path = out / INDEX_FILE
+        if index_path.exists():
+            raise click.ClickException(
+                f"既存の {INDEX_FILE} があります。--overwrite を指定してください: {out}"
+            )
+
+    parser = Pymupdf4llmParser()
     run_split(Path(pdf_path), out, chunk_size, overwrite, parser)
     generator = DefaultIndexGenerator()
     run_index(out, excerpt_lines, False, overwrite, generator)

--- a/src/pdfchunk/cli.py
+++ b/src/pdfchunk/cli.py
@@ -133,3 +133,34 @@ def index(output_dir: str, excerpt_lines: int, overwrite: bool) -> None:
     """チャンクファイル群からインデックスを生成する。"""
     generator = DefaultIndexGenerator()
     run_index(Path(output_dir), excerpt_lines, False, overwrite, generator)
+
+
+@main.command()
+@click.argument("pdf_path", type=click.Path(exists=True))
+@click.argument("output_dir", type=click.Path())
+@click.option(
+    "--chunk-size",
+    default=10,
+    type=click.IntRange(min=1),
+    help="チャンクあたりのページ数。",
+)
+@click.option(
+    "--excerpt-lines",
+    default=5,
+    type=click.IntRange(min=0),
+    help="各チャンクから抽出する抜粋行数。",
+)
+@click.option("--overwrite", is_flag=True, help="既存ファイルを上書きする。")
+def run(
+    pdf_path: str,
+    output_dir: str,
+    chunk_size: int,
+    excerpt_lines: int,
+    overwrite: bool,
+) -> None:
+    """PDFのチャンク分割からインデックス生成までを一括実行する。"""
+    parser = Pymupdf4llmParser()
+    out = Path(output_dir)
+    run_split(Path(pdf_path), out, chunk_size, overwrite, parser)
+    generator = DefaultIndexGenerator()
+    run_index(out, excerpt_lines, False, overwrite, generator)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -334,3 +334,104 @@ class TestIndexCommand:
         nonexistent = tmp_path / "no_such_dir"
         result = runner.invoke(main, ["index", str(nonexistent)])
         assert result.exit_code != 0
+
+
+class TestRunCommand:
+    """run コマンドの統合テスト。"""
+
+    @patch("pdfchunk.cli.Pymupdf4llmParser", lambda: FakeParser(total_pages=25))
+    def test_run_creates_chunks_and_index(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """チャンクファイルと index.md が一括生成されること。"""
+        dummy_pdf = tmp_path / "input" / "test.pdf"
+        dummy_pdf.parent.mkdir()
+        dummy_pdf.touch()
+        out_dir = tmp_path / "output"
+
+        result = runner.invoke(
+            main, ["run", str(dummy_pdf), str(out_dir), "--chunk-size", "10"]
+        )
+        assert result.exit_code == 0, result.output
+
+        chunk_files = sorted(out_dir.glob("[0-9][0-9][0-9][0-9].md"))
+        assert len(chunk_files) == 3
+        assert [f.name for f in chunk_files] == ["0001.md", "0002.md", "0003.md"]
+
+        index_path = out_dir / "index.md"
+        assert index_path.exists()
+        content = index_path.read_text(encoding="utf-8")
+        assert "test.pdf" in content
+        assert "0001.md" in content
+
+    def test_run_help(self, runner: CliRunner) -> None:
+        """run コマンドのヘルプが正常に表示されること。"""
+        result = runner.invoke(main, ["run", "--help"])
+        assert result.exit_code == 0
+        assert "--chunk-size" in result.output
+        assert "--excerpt-lines" in result.output
+        assert "--overwrite" in result.output
+
+    @patch("pdfchunk.cli.Pymupdf4llmParser", lambda: FakeParser(total_pages=25))
+    def test_run_with_overwrite(self, runner: CliRunner, tmp_path: Path) -> None:
+        """--overwrite ありで既存ファイルを上書きして一括生成できること。"""
+        dummy_pdf = tmp_path / "test.pdf"
+        dummy_pdf.touch()
+        out_dir = tmp_path / "output"
+        out_dir.mkdir()
+        (out_dir / "0001.md").write_text("old chunk", encoding="utf-8")
+        (out_dir / "index.md").write_text("old index", encoding="utf-8")
+
+        result = runner.invoke(
+            main, ["run", str(dummy_pdf), str(out_dir), "--overwrite"]
+        )
+        assert result.exit_code == 0, result.output
+
+        chunk_files = sorted(out_dir.glob("[0-9][0-9][0-9][0-9].md"))
+        assert len(chunk_files) == 3
+        assert (out_dir / "index.md").exists()
+
+    @patch("pdfchunk.cli.Pymupdf4llmParser", lambda: FakeParser(total_pages=25))
+    def test_run_without_overwrite_fails_on_existing_chunks(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """--overwrite なしで既存チャンクがある場合エラーになること。"""
+        dummy_pdf = tmp_path / "test.pdf"
+        dummy_pdf.touch()
+        out_dir = tmp_path / "output"
+        out_dir.mkdir()
+        (out_dir / "0001.md").write_text("existing", encoding="utf-8")
+
+        result = runner.invoke(main, ["run", str(dummy_pdf), str(out_dir)])
+        assert result.exit_code != 0
+        assert "--overwrite" in result.output
+
+    @patch("pdfchunk.cli.Pymupdf4llmParser", lambda: FakeParser(total_pages=25))
+    def test_run_excerpt_lines_option(self, runner: CliRunner, tmp_path: Path) -> None:
+        """--excerpt-lines オプションが反映されること。"""
+        dummy_pdf = tmp_path / "test.pdf"
+        dummy_pdf.touch()
+        out_dir = tmp_path / "output"
+
+        result = runner.invoke(
+            main,
+            ["run", str(dummy_pdf), str(out_dir), "--excerpt-lines", "2"],
+        )
+        assert result.exit_code == 0, result.output
+        assert (out_dir / "index.md").exists()
+
+    @patch(
+        "pdfchunk.cli.Pymupdf4llmParser",
+        lambda: ErrorParser(fail_on="get_total_pages"),
+    )
+    def test_run_split_error_propagates(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """split フェーズのエラーが伝搬されること。"""
+        dummy_pdf = tmp_path / "bad.pdf"
+        dummy_pdf.touch()
+        out_dir = tmp_path / "output"
+
+        result = runner.invoke(main, ["run", str(dummy_pdf), str(out_dir)])
+        assert result.exit_code != 0
+        assert "PDFを開けません" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -407,6 +407,23 @@ class TestRunCommand:
         assert "--overwrite" in result.output
 
     @patch("pdfchunk.cli.Pymupdf4llmParser", lambda: FakeParser(total_pages=25))
+    def test_run_without_overwrite_fails_on_existing_index(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """--overwrite なしで既存 index.md がある場合、チャンク生成前にエラーになること。"""
+        dummy_pdf = tmp_path / "test.pdf"
+        dummy_pdf.touch()
+        out_dir = tmp_path / "output"
+        out_dir.mkdir()
+        (out_dir / "index.md").write_text("existing index", encoding="utf-8")
+
+        result = runner.invoke(main, ["run", str(dummy_pdf), str(out_dir)])
+        assert result.exit_code != 0
+        assert "--overwrite" in result.output
+        # チャンクファイルが生成されていないことを確認（事前バリデーションの効果）
+        assert list(out_dir.glob("[0-9][0-9][0-9][0-9].md")) == []
+
+    @patch("pdfchunk.cli.Pymupdf4llmParser", lambda: FakeParser(total_pages=25))
     def test_run_excerpt_lines_option(self, runner: CliRunner, tmp_path: Path) -> None:
         """--excerpt-lines オプションが反映されること。"""
         dummy_pdf = tmp_path / "test.pdf"


### PR DESCRIPTION
## Summary

- `pdfchunk run <pdf_path> <output_dir>` コマンドを追加し、split → index を1コマンドで実行可能に
- READMEを `run` メインに再構成し、`split`/`index` は個別実行用として補足に配置
- CLAUDE.md の CLI仕様セクションに `run` コマンドの体系・オプション・処理フローを反映

Closes #19

## ドキュメント更新

README, CHANGELOG, CLAUDE.md を更新済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)