### PR TITLE
feat: pip install なしで python -m pdfchunk を使えるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ pip install .
 
 Python 3.13 以上が必要。
 
+### インストールせずに実行する
+
+`pip install` を行わずリポジトリルートから直接実行することもできる。
+
+```bash
+PYTHONPATH=src python -m pdfchunk run report.pdf output/
+```
+
 ## 使い方
 
 ### 一括実行（run）

--- a/src/pdfchunk/__main__.py
+++ b/src/pdfchunk/__main__.py
@@ -1,0 +1,4 @@
+from pdfchunk.cli import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

`pip install` を行わずリポジトリルートから直接 `python -m pdfchunk` で実行できるようにする。

- `src/pdfchunk/__main__.py` を追加し、`-m pdfchunk` のエントリポイントを提供
- README にインストール不要の実行方法を追記

## ドキュメント

README の「インストール」セクションに `PYTHONPATH=src python -m pdfchunk` の使い方を追記済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)